### PR TITLE
add button to clear tasks and corresponding backend changes

### DIFF
--- a/backend/src/handlers/tasks.ts
+++ b/backend/src/handlers/tasks.ts
@@ -6,6 +6,7 @@ import {
   taskCreateSchema,
   tasksList,
   tasksRemove,
+  tasksClearByUser,
 } from "../models/task";
 
 // Create a new task. The body of the request is an object that matches
@@ -27,6 +28,13 @@ export const listTasks = async (ctx: Context, next: Next) => {
 // Remove a task given its userId and id
 export const removeTask = async (ctx: Context, next: Next) => {
   tasksRemove(ctx.params.userId, ctx.params.taskId);
+  ctx.body = {};
+  await next();
+};
+
+// Removes all tasks of a given user.
+export const clearUserTasks = async (ctx: Context, next: Next) => {
+  tasksClearByUser(ctx.params.userId);
   ctx.body = {};
   await next();
 };

--- a/backend/src/models/task.ts
+++ b/backend/src/models/task.ts
@@ -66,3 +66,12 @@ export const tasksRemove = (userId: string, taskId: string) => {
     console.warn("User not found");
   }
 };
+
+// Removes all tasks from a given user.
+export const tasksClearByUser = (userId: string) => {
+  if (tasks[userId]) {
+    tasks[userId] = [];
+  } else {
+    console.warn("User not found");
+  }
+};

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -3,7 +3,12 @@
 
 import * as Router from "@koa/router";
 import { createUser, listUsers } from "./handlers/users";
-import { createTask, listTasks, removeTask } from "./handlers/tasks";
+import {
+  createTask,
+  listTasks,
+  removeTask,
+  clearUserTasks,
+} from "./handlers/tasks";
 
 export const router = new Router();
 router.get("/api/users", listUsers);
@@ -11,3 +16,4 @@ router.post("/api/users", createUser);
 router.post("/api/tasks", createTask);
 router.get("/api/tasks/:userId", listTasks);
 router.delete("/api/tasks/:userId/:taskId", removeTask);
+router.delete("/api/tasks/:userId", clearUserTasks);

--- a/backend/tests/handlers/tasks.spec.ts
+++ b/backend/tests/handlers/tasks.spec.ts
@@ -53,3 +53,20 @@ test("removeTask", async () => {
     .expect(200);
   expect(res.body).toEqual({});
 });
+
+test("clearUserTasks", async () => {
+  const task1 = tasksAdd({
+    userId: kermit.id,
+    task: "be nice to piggy",
+  });
+  const task2 = tasksAdd({
+    userId: kermit.id,
+    task: "be nice to piggy",
+  });
+  const res = await request(app.callback())
+    .delete(`/api/tasks/${kermit.id}`)
+    .set("Content-Type", "application/json")
+    .send()
+    .expect(200);
+  expect(res.body).toEqual({});
+});

--- a/backend/tests/models/task.spec.ts
+++ b/backend/tests/models/task.spec.ts
@@ -1,6 +1,6 @@
 // Tests for our Task model.
 
-import { tasks, tasksAdd, tasksClear, tasksList, tasksRemove } from "../../src/models/task";
+import { tasks, tasksAdd, tasksClear, tasksList, tasksRemove, tasksClearByUser } from "../../src/models/task";
 import { usersAdd, User } from "../../src/models/user";
 import { clearState } from "../../src/models";
 
@@ -57,4 +57,14 @@ test("tasksRemove", () => {
   tasksRemove(kermitTask.userId, kermitTask.id);
   expect(tasks[kermit.id]).toEqual(expect.not.arrayContaining([kermitTask]));
   expect(tasks[kermit.id]).toEqual(expect.arrayContaining([kermitTask2]));
+});
+
+test("tasksClearByUser", () => {
+  tasksAdd({ userId: kermit.id, task: "be nice to piggy" });
+  tasksAdd({ userId: kermit.id, task: "laugh at fozzy" });
+  const piggyTask = tasksAdd({ userId: piggy.id, task: "marry kermit" });
+  
+  tasksClearByUser(kermit.id);
+  expect(tasks[kermit.id]).toEqual([]);
+  expect(tasks[piggy.id]).toEqual(expect.arrayContaining([piggyTask]));
 });

--- a/frontend/src/components/ClearTasks.vue
+++ b/frontend/src/components/ClearTasks.vue
@@ -1,0 +1,25 @@
+<script setup>
+// The UI for adding a task.
+import { MinusCircleIcon } from "@heroicons/vue/solid";
+import { useTaskStore } from "@/stores/task";
+
+const taskStore = useTaskStore();
+
+// Clears the task list for the current logged in user.
+// Triggered when the user hits the 'Clear list' button.
+const clearTasks = async () => {
+  await taskStore.clearTasks();
+};
+</script>
+
+<template>
+  <button
+    v-if="taskStore.tasks.length > 0"
+    type="button"
+    class="-ml-px inline-flex items-center h-10 space-x-2 px-4 py-2 border border-gray-300 text-sm font-medium rounded text-gray-700 bg-gray-50 hover:bg-gray-100 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
+    @click="clearTasks()"
+  >
+    <MinusCircleIcon class="h-5 w-5 text-gray-400" aria-hidden="true" />
+    <span>Clear tasks</span>
+  </button>
+</template>

--- a/frontend/src/components/TasklyMain.vue
+++ b/frontend/src/components/TasklyMain.vue
@@ -11,6 +11,7 @@ import {
 } from "@headlessui/vue";
 import { BellIcon, MenuIcon, XIcon } from "@heroicons/vue/outline";
 import AddTask from "./AddTask.vue";
+import ClearTasks from "./ClearTasks.vue";
 import ListTasks from "./ListTasks.vue";
 import { useUserStore } from "@/stores/user";
 import { useTaskStore } from "@/stores/task";
@@ -195,7 +196,10 @@ const signOut = () => {
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
           <div class="px-4 py-8 sm:px-0">
             <div class="flex flex-col w-full p-8">
-              <AddTask class="md:w-1/2" />
+              <div class="flex justify-between items-end w-full">
+                <AddTask />
+                <ClearTasks />
+              </div>
               <Suspense>
                 <ListTasks class="pt-4" />
                 <template #fallback> ... loading tasks ... </template>

--- a/frontend/src/stores/task.ts
+++ b/frontend/src/stores/task.ts
@@ -58,6 +58,18 @@ export const useTaskStore = defineStore({
         console.log("Cannot remove a task without a logged in user; bug!");
       }
     },
+    // Clear the tasks list, then update the list of tasks. It
+    // is a bug to call this action when a user is not logged in; we
+    // currently just log to the console if that happens.
+    async clearTasks() {
+      const userStore = useUserStore();
+      if (userStore.user) {
+        await taskApi.delete(userStore.user.id);
+        await this.getTasks();
+      } else {
+        console.log("Cannot clear tasks without a logged in user; bug!");
+      }
+    },
     // Reset the list of tasks to the initial state (empty).
     clear() {
       this.tasks = [];


### PR DESCRIPTION
When developing the feature of tasks removal, I realized that the task of deleting each tasks one-by-one can be a little cumbersome for the users. To address this issue, I'm proposing a way to clear all tasks at once.
This PR adds a button in the tasks list that allows users to clear all their tasks. The button is only visible when the user has tasks.
Before clicking:
![image](https://user-images.githubusercontent.com/9059660/174408614-3b1e0691-4ea4-41c0-a8ea-3c7609d19953.png)
After clicking:
![image](https://user-images.githubusercontent.com/9059660/174408651-6222d5f0-aeda-41c0-b517-1e035e47d574.png)
